### PR TITLE
fix(storage): 修复S3路径样式端点配置的布尔值转换问题

### DIFF
--- a/src/plugin/saiadmin/service/storage/UploadService.php
+++ b/src/plugin/saiadmin/service/storage/UploadService.php
@@ -108,7 +108,8 @@ class UploadService
                     'domain' => Arr::getConfigValue($uploadConfig,'s3_domain'),
                     'region' => Arr::getConfigValue($uploadConfig,'s3_region'),
                     'version' => Arr::getConfigValue($uploadConfig,'s3_version'),
-                    'use_path_style_endpoint' => Arr::getConfigValue($uploadConfig,'s3_use_path_style_endpoint'),
+                    // 'use_path_style_endpoint' => Arr::getConfigValue($uploadConfig,'s3_use_path_style_endpoint'),
+                    'use_path_style_endpoint' => filter_var(Arr::getConfigValue($uploadConfig,'s3_use_path_style_endpoint'), FILTER_VALIDATE_BOOLEAN),
                     'endpoint' => Arr::getConfigValue($uploadConfig,'s3_endpoint'),
                     'acl' => Arr::getConfigValue($uploadConfig,'s3_acl'),
                 ];


### PR DESCRIPTION
问题出现在 UploadService 中， UploadService.php:111 直接使用 Arr::getConfigValue() 返回的字符串值，但 S3 适配器严格要求布尔类型。

Arr::getConfigValue() 方法 Arr.php:194-202 从数据库配置中返回的始终是字符串类型。