### PR TITLE
Fix:修复了安装脚本错误的生成配置文件的问题

### DIFF
--- a/src/plugin/saiadmin/app/controller/InstallController.php
+++ b/src/plugin/saiadmin/app/controller/InstallController.php
@@ -292,7 +292,7 @@ return [
     ],
 ];
 EOF;
-        file_put_contents(base_path() . '/config/think-orm.php', $think_cache_config);
+        file_put_contents(base_path() . '/config/think-cache.php', $think_cache_config);
 
     }
 


### PR DESCRIPTION
安装程序在 
generateConfig()方法中：

先正确地把数据库配置写入 
config/think-orm.php第201行）

然后又错误地把 think-cache 配置也写入了 
config/think-orm.php（第295行）

第295行应该是 
think-cache.php，但写成了 think-orm.php，覆盖了之前正确的数据库配置