### PR TITLE
fix(cache): recover malformed tag indexes

### DIFF
--- a/src/plugin/saiadmin/app/cache/CacheTag.php
+++ b/src/plugin/saiadmin/app/cache/CacheTag.php
@@ -1,0 +1,44 @@
+<?php
+// +----------------------------------------------------------------------
+// | saiadmin [ saiadmin快速开发框架 ]
+// +----------------------------------------------------------------------
+// | Author: sai <1430792918@qq.com>
+// +----------------------------------------------------------------------
+declare(strict_types=1);
+
+namespace plugin\saiadmin\app\cache;
+
+use InvalidArgumentException;
+use support\think\Cache;
+
+/**
+ * 标签缓存写入辅助类
+ */
+class CacheTag
+{
+    /**
+     * 写入带标签的缓存，并在标签索引被旧值污染时自动恢复。
+     *
+     * @param array|string $tags
+     * @param mixed $value
+     */
+    public static function set(array|string $tags, string $key, mixed $value, int $expire): bool
+    {
+        $tags = (array) $tags;
+
+        try {
+            return Cache::tag($tags)->set($key, $value, $expire);
+        } catch (InvalidArgumentException $exception) {
+            if ($exception->getMessage() !== 'only array cache can be push') {
+                throw $exception;
+            }
+
+            $store = Cache::store();
+            foreach ($tags as $tag) {
+                $store->delete($store->getTagKey($tag));
+            }
+
+            return Cache::tag($tags)->set($key, $value, $expire);
+        }
+    }
+}

--- a/src/plugin/saiadmin/app/cache/ConfigCache.php
+++ b/src/plugin/saiadmin/app/cache/ConfigCache.php
@@ -69,7 +69,7 @@ class ConfigCache
         $tag[] = $cache['tag'];
 
         // 保存到缓存
-        Cache::tag($tag)->set($cache['prefix'] . md5($code), $data, $cache['expire']);
+        CacheTag::set($tag, $cache['prefix'] . md5($code), $data, $cache['expire']);
         return $data;
     }
 

--- a/src/plugin/saiadmin/app/cache/ReflectionCache.php
+++ b/src/plugin/saiadmin/app/cache/ReflectionCache.php
@@ -55,7 +55,7 @@ class ReflectionCache
             $data = [];
         }
 
-        Cache::tag($tag)->set($key, $data, $cache['expire']);
+        CacheTag::set($tag, $key, $data, $cache['expire']);
         return $data;
     }
 
@@ -87,7 +87,7 @@ class ReflectionCache
             }
         }
 
-        Cache::tag($tag)->set($key, $data, $cache['expire']);
+        CacheTag::set($tag, $key, $data, $cache['expire']);
         return $data;
     }
 

--- a/src/plugin/saiadmin/app/cache/UserAuthCache.php
+++ b/src/plugin/saiadmin/app/cache/UserAuthCache.php
@@ -81,7 +81,7 @@ class UserAuthCache
         }
 
         // 保存到缓存
-        Cache::tag($tag)->set($cache['prefix'] . $uid, $data, $cache['expire']);
+        CacheTag::set($tag, $cache['prefix'] . $uid, $data, $cache['expire']);
         return $data;
     }
 
@@ -100,7 +100,7 @@ class UserAuthCache
         $all = (new SystemMenuLogic())->getAllAuth();
 
         // 设置权限并返回
-        Cache::tag($cache['tag'])->set($cache['all'], $all, $cache['expire']);
+        CacheTag::set($cache['tag'], $cache['all'], $all, $cache['expire']);
 
         return $all;
     }

--- a/src/plugin/saiadmin/app/cache/UserInfoCache.php
+++ b/src/plugin/saiadmin/app/cache/UserInfoCache.php
@@ -78,7 +78,7 @@ class UserInfoCache
                 $tags[] = $cache['post'] . $post['id'];
             }
         }
-        Cache::tag($tags)->set($cache['prefix'] . $uid, $data, $cache['expire']);
+        CacheTag::set($tags, $cache['prefix'] . $uid, $data, $cache['expire']);
         return $data;
     }
 

--- a/src/plugin/saiadmin/app/cache/UserMenuCache.php
+++ b/src/plugin/saiadmin/app/cache/UserMenuCache.php
@@ -74,7 +74,7 @@ class UserMenuCache
         }
 
         // 保存到缓存
-        Cache::tag($tag)->set($cache['prefix'] . $uid, $data, $cache['expire']);
+        CacheTag::set($tag, $cache['prefix'] . $uid, $data, $cache['expire']);
         return $data;
     }
 


### PR DESCRIPTION
## Summary
- Recover a malformed or legacy cache tag index when it causes `only array cache can be push`.
- Route SaiAdmin cache writers through one shared recovery helper.

## Validation
- `php -l` on all changed PHP files
- `composer validate --no-check-publish`
- `git diff --check`